### PR TITLE
Alter error handling - removing URL codes

### DIFF
--- a/VizNetworkApp/Requests Manager/NetworkManager.swift
+++ b/VizNetworkApp/Requests Manager/NetworkManager.swift
@@ -7,7 +7,23 @@
 import Foundation
 
 enum NetworkError: Error {
-    case urlError(URLError)
+    case cannotDecodeContentData
+    case unknown
+    case cancelled
+    case badURL
+    
+    func errorDescription() -> String {
+        switch self {
+        case .cannotDecodeContentData:
+            return "cannotDecodeContentData"
+        case .unknown:
+            return "unknown"
+        case .cancelled:
+            return "cancelled"
+        case .badURL:
+            return "badURL"
+        }
+    }
 }
 
 class NetworkManager {
@@ -40,7 +56,7 @@ class NetworkManager {
                                                             response: response,
                                                             error: error) { result in
                     guard operation.isCancelled == false else {
-                        completion(.failure(NetworkError.urlError(URLError(.cancelled))))
+                        completion(.failure(NetworkError.cancelled))
                         group.leave()
                         return
                     }
@@ -86,7 +102,7 @@ class NetworkManager {
             if let err = error {
                 completion(.failure(err))
             } else {
-                completion(.failure(NetworkError.urlError(URLError(.unknown))))
+                completion(.failure(NetworkError.unknown))
             }
             return
         }
@@ -98,7 +114,7 @@ class NetworkManager {
         guard let data = data,
               let value =  try? JSONDecoder().decode(responseModel, from: data) else {
             DispatchQueue.main.async {
-                completion(.failure(NetworkError.urlError(URLError(.cannotDecodeContentData))))
+                completion(.failure(NetworkError.cannotDecodeContentData))
             }
             return
         }

--- a/VizNetworkApp/Requests/NetworkRequest.swift
+++ b/VizNetworkApp/Requests/NetworkRequest.swift
@@ -39,7 +39,7 @@ class ApiNetworkRequest<APIResource: ApiResource> : NetworkRequest {
     func execute(withCompletion completion: @escaping (Result<APIResource.ModelType, Error>) -> Void) -> String where APIResource: HttpApiResource {
         guard let request = apiResource.urlRequest() else {
             print("could not get url request")
-            completion(.failure(NetworkError.urlError(URLError(.badURL))))
+            completion(.failure(NetworkError.badURL))
             return failedToRetrieveUrlFromApiResource
         }
         return load(request, completion: completion)

--- a/VizNetworkApp/ViewController.swift
+++ b/VizNetworkApp/ViewController.swift
@@ -30,7 +30,11 @@ class ViewController: UIViewController, UITableViewDataSource {
                 self?.usersList = object
                 self?.tableView.reloadData()
             case .failure(let error):
-                print(error)
+                if let error = error as? NetworkError {
+                    print(error.errorDescription())
+                } else {
+                    print(error.localizedDescription)
+                }
             }
         }
     }


### PR DESCRIPTION
### Note the base branch

Per our conversation, i did check that we can get the data we need from error. And it seem like our best options is to enumerate errors our selves instead of using `urlError(URLError)`. 

When i did debug usage of  `urlError(URLError)` i could not get the info i want per relevant code. 

However, using this method - all seem to work as we want.

Please let me know if you see this differently and i will be happy to change again 🙏 